### PR TITLE
Fixed the branch name in CW Events Rule

### DIFF
--- a/cloudformation_template.yml
+++ b/cloudformation_template.yml
@@ -444,7 +444,7 @@ Resources:
   CodeCommitEvent:
     Type: AWS::Events::Rule
     Properties:
-      Description: "Trigger CodePipeline whenever there's a commit to the master branch"
+      Description: "Trigger CodePipeline whenever there's a commit to the main branch"
       State: "ENABLED"
       EventPattern:
         source:
@@ -460,7 +460,7 @@ Resources:
           referenceType:
             - "branch"
           referenceName:
-            - "master"
+            - "main"
       Targets:
         - Arn: !Sub
             - "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${pipelineName}"


### PR DESCRIPTION
CW Event rule is pointing to master branch where as Code Pipeline is pulling the code from main branch. Fixed the Events rule to match events on main branch.